### PR TITLE
Enforce review visibility on backend and add draft-first UX on frontend

### DIFF
--- a/packages/backend/convex/reviews.ts
+++ b/packages/backend/convex/reviews.ts
@@ -254,13 +254,16 @@ export const listByUser = query({
   },
   handler: async (ctx, args) => {
     const limit = args.limit ?? 20;
+    const identity = await ctx.auth.getUserIdentity();
+    const isOwnReviews = identity?.subject === args.userId;
+    const visibleStatus = isOwnReviews ? args.status : 'PUBLISHED';
 
     let q = ctx.db
       .query('reviews')
       .withIndex('by_user', (q) => q.eq('userId', args.userId));
 
-    if (args.status) {
-      q = q.filter((q) => q.eq(q.field('status'), args.status));
+    if (visibleStatus) {
+      q = q.filter((q) => q.eq(q.field('status'), visibleStatus));
     }
 
     const reviews = await q.order('desc').take(limit);
@@ -306,7 +309,20 @@ export const get = query({
     id: v.id('reviews'),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return null;
+    }
+
     const review = await ctx.db.get(args.id);
+    if (!review || review.status === 'DELETED') {
+      return null;
+    }
+
+    if (review.userId !== identity.subject) {
+      return null;
+    }
+
     return review;
   },
 });
@@ -320,6 +336,11 @@ export const getByUserAndBook = query({
     bookId: v.id('books'),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity?.subject !== args.userId) {
+      return null;
+    }
+
     const review = await ctx.db
       .query('reviews')
       .withIndex('by_user_book', (q) =>
@@ -668,8 +689,14 @@ export const getDetail = query({
     userId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    const viewerUserId = identity?.subject;
     const review = await ctx.db.get(args.id);
-    if (!review) {
+    if (!review || review.status === 'DELETED') {
+      return null;
+    }
+
+    if (review.status === 'DRAFT' && review.userId !== viewerUserId) {
       return null;
     }
 
@@ -692,8 +719,8 @@ export const getDetail = query({
     let hasLiked = false;
     let hasBookmarked = false;
 
-    const userId = args.userId;
-    if (userId) {
+    const userId = viewerUserId === args.userId ? viewerUserId : undefined;
+    if (userId && review.status === 'PUBLISHED') {
       // 좋아요 여부 확인
       const like = await ctx.db
         .query('likes')

--- a/packages/frontend/src/components/review/ReviewForm.tsx
+++ b/packages/frontend/src/components/review/ReviewForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   ThumbsUp,
   ThumbsDown,
@@ -20,14 +20,23 @@ interface ReviewFormData {
 
 interface ReviewFormProps {
   initialData?: Partial<ReviewFormData>;
-  onSubmit: (data: ReviewFormData, status: 'DRAFT' | 'PUBLISHED') => void;
+  onSubmit: (
+    data: ReviewFormData,
+    status: 'DRAFT' | 'PUBLISHED'
+  ) => void | Promise<void>;
   isSubmitting?: boolean;
+  submittingStatus?: 'DRAFT' | 'PUBLISHED' | null;
+  currentStatus?: 'DRAFT' | 'PUBLISHED';
+  lastSavedAt?: number | null;
 }
 
 export function ReviewForm({
   initialData,
   onSubmit,
   isSubmitting = false,
+  submittingStatus = null,
+  currentStatus,
+  lastSavedAt = null,
 }: ReviewFormProps) {
   const [formData, setFormData] = useState<ReviewFormData>({
     title: initialData?.title || '',
@@ -36,19 +45,44 @@ export function ReviewForm({
     readStatus: initialData?.readStatus || 'COMPLETED',
   });
 
+  const contentLength = formData.content.length;
+  const minLength = 10;
+  const isContentValid = contentLength >= minLength;
+  const hasDraftContent = Boolean(
+    formData.title.trim() || formData.content.trim()
+  );
+  const formattedLastSavedAt = useMemo(() => {
+    if (!lastSavedAt) return null;
+
+    return new Intl.DateTimeFormat('ko-KR', {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(lastSavedAt));
+  }, [lastSavedAt]);
+
   const handleSubmit = (status: 'DRAFT' | 'PUBLISHED') => {
-    // Validate required fields
+    if (status === 'DRAFT') {
+      if (!hasDraftContent) {
+        toast.warning('저장할 제목이나 내용을 입력해주세요');
+        return;
+      }
+
+      Promise.resolve(onSubmit(formData, status)).catch(() => undefined);
+      return;
+    }
+
     if (!formData.content.trim()) {
       toast.warning('독후감 내용을 입력해주세요');
       return;
     }
 
-    onSubmit(formData, status);
-  };
+    if (!isContentValid) {
+      toast.warning(`독후감은 ${minLength}자 이상 작성해주세요`);
+      return;
+    }
 
-  const contentLength = formData.content.length;
-  const minLength = 10;
-  const isContentValid = contentLength >= minLength;
+    Promise.resolve(onSubmit(formData, status)).catch(() => undefined);
+  };
 
   return (
     <div className="paper-surface flex min-h-0 flex-col gap-8 p-6 md:p-8 rounded-2xl">
@@ -214,25 +248,43 @@ export function ReviewForm({
       </div>
 
       {/* Action buttons */}
-      <div className="flex gap-4 pt-6 border-t border-paper-200/70">
-        <Button
-          variant="outline"
-          onClick={() => handleSubmit('DRAFT')}
-          disabled={isSubmitting || !isContentValid}
-          className="flex-1 h-12 text-base rounded-xl border-stone-200 hover:bg-stone-50 hover:border-stone-300"
-        >
-          <Save className="w-4 h-4 mr-2" />
-          초안 저장
-        </Button>
-        <Button
-          variant="warm"
-          onClick={() => handleSubmit('PUBLISHED')}
-          disabled={isSubmitting || !isContentValid}
-          className="flex-[2] h-12 text-base rounded-xl"
-        >
-          <Send className="w-4 h-4 mr-2" />
-          발행하기
-        </Button>
+      <div className="space-y-3 border-t border-paper-200/70 pt-6">
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Button
+            variant="outline"
+            onClick={() => handleSubmit('DRAFT')}
+            disabled={isSubmitting}
+            className="h-12 flex-1 rounded-xl border-stone-200 text-base hover:border-stone-300 hover:bg-stone-50"
+          >
+            <Save className="w-4 h-4 mr-2" />
+            {submittingStatus === 'DRAFT' ? '저장 중...' : '초안 저장'}
+          </Button>
+          <Button
+            variant="warm"
+            onClick={() => handleSubmit('PUBLISHED')}
+            disabled={isSubmitting || !isContentValid}
+            className="h-12 flex-[2] rounded-xl text-base"
+          >
+            <Send className="w-4 h-4 mr-2" />
+            {submittingStatus === 'PUBLISHED' ? '발행 중...' : '발행하기'}
+          </Button>
+        </div>
+        <div className="rounded-xl bg-primary-50/70 px-4 py-3 text-sm text-primary-800 ring-1 ring-primary-100">
+          {formattedLastSavedAt ? (
+            <span>
+              {formattedLastSavedAt}에 초안이 저장되었습니다. 이 화면에서 계속
+              이어서 작성할 수 있어요.
+            </span>
+          ) : currentStatus === 'DRAFT' ? (
+            <span>
+              저장된 초안을 이어 쓰는 중입니다. 발행 전까지 나만 볼 수 있어요.
+            </span>
+          ) : (
+            <span>
+              초안 저장은 작성 화면을 벗어나지 않고 현재 내용을 보관합니다.
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/reviews/MyReviewCard.tsx
+++ b/packages/frontend/src/components/reviews/MyReviewCard.tsx
@@ -44,6 +44,7 @@ export function MyReviewCard({ review, dateFormatter }: MyReviewCardProps) {
   const hasReviewTitle = Boolean(review.title?.trim());
   const reviewTitle = review.title?.trim() || '제목 없는 독후감';
   const bookTitle = book?.title || '도서 정보 없음';
+  const isDraft = review.status === 'DRAFT';
   const statusBadge =
     review.status === 'DRAFT' ? (
       <Badge variant="secondary" className="text-xs">
@@ -150,28 +151,57 @@ export function MyReviewCard({ review, dateFormatter }: MyReviewCardProps) {
           </div>
 
           <div className="flex shrink-0 gap-1">
-            <Button
-              asChild
-              variant="ghost"
-              size="sm"
-              className="h-8 px-3 text-xs text-stone-700 hover:bg-paper-100/70 hover:text-stone-950"
-            >
-              <Link to={`/reviews/${review._id}`}>
-                <Eye className="h-4 w-4" aria-hidden="true" />
-                보기
-              </Link>
-            </Button>
-            <Button
-              asChild
-              variant="ghost"
-              size="sm"
-              className="h-8 px-3 text-xs text-stone-700 hover:bg-paper-100/70 hover:text-stone-950"
-            >
-              <Link to={`/reviews/${review._id}/edit`}>
-                <Edit className="h-4 w-4" aria-hidden="true" />
-                수정
-              </Link>
-            </Button>
+            {isDraft ? (
+              <>
+                <Button
+                  asChild
+                  variant="default"
+                  size="sm"
+                  className="h-8 px-3 text-xs"
+                >
+                  <Link to={`/reviews/${review._id}/edit`}>
+                    <Edit className="h-4 w-4" aria-hidden="true" />
+                    이어쓰기
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-3 text-xs text-stone-700 hover:bg-paper-100/70 hover:text-stone-950"
+                >
+                  <Link to={`/reviews/${review._id}`}>
+                    <Eye className="h-4 w-4" aria-hidden="true" />
+                    미리보기
+                  </Link>
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-3 text-xs text-stone-700 hover:bg-paper-100/70 hover:text-stone-950"
+                >
+                  <Link to={`/reviews/${review._id}`}>
+                    <Eye className="h-4 w-4" aria-hidden="true" />
+                    보기
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-3 text-xs text-stone-700 hover:bg-paper-100/70 hover:text-stone-950"
+                >
+                  <Link to={`/reviews/${review._id}/edit`}>
+                    <Edit className="h-4 w-4" aria-hidden="true" />
+                    수정
+                  </Link>
+                </Button>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/packages/frontend/src/pages/ReviewDetail/ReviewDetailPage.tsx
+++ b/packages/frontend/src/pages/ReviewDetail/ReviewDetailPage.tsx
@@ -102,6 +102,7 @@ export function ReviewDetailPage() {
   // - Skip if already viewed in this session
   useEffect(() => {
     if (!review || !id || hasIncrementedViewCount.current) return;
+    if (review.status !== 'PUBLISHED') return;
 
     // Skip if this is the author viewing their own review
     if (user?.id && review.userId === user.id) {
@@ -137,11 +138,11 @@ export function ReviewDetailPage() {
   }, [review, id, user?.id, incrementViewCount]);
 
   const handleBack = useCallback((): void => {
-    void navigate('/feed');
-  }, [navigate]);
+    void navigate(review?.status === 'DRAFT' ? '/dashboard' : '/feed');
+  }, [navigate, review?.status]);
 
   const handleLike = useCallback((): void => {
-    if (!review || !id) return;
+    if (!review || !id || review.status !== 'PUBLISHED') return;
 
     // T108: Check authentication before allowing like
     if (!isSignedIn) {
@@ -156,7 +157,7 @@ export function ReviewDetailPage() {
   }, [review, id, isSignedIn, showLoginPrompt, toggleLike]);
 
   const handleBookmark = useCallback((): void => {
-    if (!review || !id) return;
+    if (!review || !id || review.status !== 'PUBLISHED') return;
 
     // T108: Check authentication before allowing bookmark
     if (!isSignedIn) {
@@ -173,7 +174,13 @@ export function ReviewDetailPage() {
   }, [review, id, isSignedIn, showLoginPrompt, toggleBookmark]);
 
   const handleShare = useCallback((): void => {
-    if (typeof window === 'undefined' || !review) return;
+    if (
+      typeof window === 'undefined' ||
+      !review ||
+      review.status !== 'PUBLISHED'
+    ) {
+      return;
+    }
 
     const url = (window as Window).location.href;
     const title = review.title || '독후감';
@@ -201,14 +208,14 @@ export function ReviewDetailPage() {
 
     void deleteReview({ id: id as Id<'reviews'> })
       .then(() => {
-        void navigate('/feed');
+        void navigate(review?.status === 'DRAFT' ? '/dashboard' : '/feed');
       })
       .catch((err: unknown) => {
         toast.error('독후감 삭제에 실패했습니다', '다시 시도해주세요.');
         logError(err, 'Delete review failed');
         setShowDeleteModal(false);
       });
-  }, [id, deleteReview, navigate]);
+  }, [id, deleteReview, navigate, review?.status]);
 
   // Loading state
   if (review === undefined) {
@@ -250,6 +257,8 @@ export function ReviewDetailPage() {
     );
   }
 
+  const isDraft = review.status === 'DRAFT';
+  const isAuthor = Boolean(user && review.userId === user.id);
   const book = review.book;
   const bookPublishYear = book?.publishedDate
     ? new Date(book.publishedDate).getFullYear()
@@ -285,7 +294,7 @@ export function ReviewDetailPage() {
           </Button>
 
           {/* Mobile Action Buttons (Edit/Delete) - visible only for author */}
-          {user && review.userId === user.id && (
+          {isAuthor && (
             <div className="sm:hidden flex gap-1">
               <Button
                 variant="ghost"
@@ -306,6 +315,18 @@ export function ReviewDetailPage() {
             </div>
           )}
         </nav>
+
+        {isDraft && (
+          <div className="mb-8 rounded-2xl bg-primary-50/80 p-4 text-primary-900 ring-1 ring-primary-100 sm:p-5">
+            <p className="text-sm font-semibold">
+              아직 발행되지 않은 초안입니다
+            </p>
+            <p className="mt-1 text-sm text-primary-800">
+              이 글은 작성자 본인만 볼 수 있어요. 계속 작성한 뒤 발행하면 피드와
+              책 상세에 공개됩니다.
+            </p>
+          </div>
+        )}
 
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12">
           {/* Main Content Area */}
@@ -363,13 +384,15 @@ export function ReviewDetailPage() {
                         `사용자 ${review.userId.slice(-4)}`}
                     </p>
                     <p className="text-sm text-stone-500">
-                      View {review.viewCount.toLocaleString()}
+                      {isDraft
+                        ? '발행 전까지 비공개'
+                        : `View ${review.viewCount.toLocaleString()}`}
                     </p>
                   </div>
                 </div>
 
                 {/* Desktop Action Buttons (Edit/Delete) */}
-                {user && review.userId === user.id && (
+                {isAuthor && (
                   <div className="hidden sm:flex gap-2">
                     <Button
                       variant="outline"
@@ -378,7 +401,7 @@ export function ReviewDetailPage() {
                       className="text-stone-600 hover:text-primary-600 hover:border-primary-200"
                     >
                       <Edit className="w-4 h-4 mr-1.5" />
-                      수정
+                      {isDraft ? '계속 작성' : '수정'}
                     </Button>
                     <Button
                       variant="outline"
@@ -405,53 +428,57 @@ export function ReviewDetailPage() {
             </m.article>
 
             {/* Interaction Bar */}
-            <div className="flex items-center justify-center gap-6 py-8 border-t border-stone-200 mt-12">
-              <Button
-                variant="ghost"
-                size="lg"
-                onClick={handleLike}
-                className={`flex flex-col gap-1 h-auto py-3 px-6 rounded-xl transition-all duration-300 ${
-                  review.hasLiked
-                    ? 'bg-red-50 text-red-600 hover:bg-red-100'
-                    : 'text-stone-500 hover:bg-stone-100 hover:text-stone-900'
-                }`}
-              >
-                <Heart
-                  className={`w-8 h-8 ${review.hasLiked ? 'fill-current' : ''}`}
-                />
-                <span className="text-xs font-medium">{review.likeCount}</span>
-              </Button>
+            {!isDraft && (
+              <div className="flex items-center justify-center gap-6 py-8 border-t border-stone-200 mt-12">
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  onClick={handleLike}
+                  className={`flex flex-col gap-1 h-auto py-3 px-6 rounded-xl transition-all duration-300 ${
+                    review.hasLiked
+                      ? 'bg-red-50 text-red-600 hover:bg-red-100'
+                      : 'text-stone-500 hover:bg-stone-100 hover:text-stone-900'
+                  }`}
+                >
+                  <Heart
+                    className={`w-8 h-8 ${review.hasLiked ? 'fill-current' : ''}`}
+                  />
+                  <span className="text-xs font-medium">
+                    {review.likeCount}
+                  </span>
+                </Button>
 
-              <div className="w-px h-12 bg-stone-200" />
+                <div className="w-px h-12 bg-stone-200" />
 
-              <Button
-                variant="ghost"
-                size="lg"
-                onClick={handleBookmark}
-                className={`flex flex-col gap-1 h-auto py-3 px-6 rounded-xl transition-all duration-300 ${
-                  review.hasBookmarked
-                    ? 'bg-amber-50 text-amber-600 hover:bg-amber-100'
-                    : 'text-stone-500 hover:bg-stone-100 hover:text-stone-900'
-                }`}
-              >
-                <Bookmark
-                  className={`w-8 h-8 ${review.hasBookmarked ? 'fill-current' : ''}`}
-                />
-                <span className="text-xs font-medium">저장</span>
-              </Button>
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  onClick={handleBookmark}
+                  className={`flex flex-col gap-1 h-auto py-3 px-6 rounded-xl transition-all duration-300 ${
+                    review.hasBookmarked
+                      ? 'bg-amber-50 text-amber-600 hover:bg-amber-100'
+                      : 'text-stone-500 hover:bg-stone-100 hover:text-stone-900'
+                  }`}
+                >
+                  <Bookmark
+                    className={`w-8 h-8 ${review.hasBookmarked ? 'fill-current' : ''}`}
+                  />
+                  <span className="text-xs font-medium">저장</span>
+                </Button>
 
-              <div className="w-px h-12 bg-stone-200" />
+                <div className="w-px h-12 bg-stone-200" />
 
-              <Button
-                variant="ghost"
-                size="lg"
-                onClick={handleShare}
-                className="flex flex-col gap-1 h-auto py-3 px-6 rounded-xl text-stone-500 hover:bg-stone-100 hover:text-primary-600 transition-all duration-300"
-              >
-                <Share2 className="w-8 h-8" />
-                <span className="text-xs font-medium">공유</span>
-              </Button>
-            </div>
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  onClick={handleShare}
+                  className="flex flex-col gap-1 h-auto py-3 px-6 rounded-xl text-stone-500 hover:bg-stone-100 hover:text-primary-600 transition-all duration-300"
+                >
+                  <Share2 className="w-8 h-8" />
+                  <span className="text-xs font-medium">공유</span>
+                </Button>
+              </div>
+            )}
           </main>
 
           {/* Sidebar: Book Info */}

--- a/packages/frontend/src/pages/ReviewEdit/ReviewEditPage.tsx
+++ b/packages/frontend/src/pages/ReviewEdit/ReviewEditPage.tsx
@@ -18,11 +18,15 @@ interface ReviewFormData {
   readStatus: 'READING' | 'COMPLETED' | 'DROPPED';
 }
 
+type ReviewSubmitStatus = 'DRAFT' | 'PUBLISHED';
+
 export default function ReviewEditPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { user } = useUser();
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submittingStatus, setSubmittingStatus] =
+    useState<ReviewSubmitStatus | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
 
   // Fetch review data
   const review = useQuery(
@@ -50,30 +54,40 @@ export default function ReviewEditPage() {
 
   const handleSubmitReview = async (
     data: ReviewFormData,
-    status: 'DRAFT' | 'PUBLISHED'
+    status: ReviewSubmitStatus
   ) => {
     if (!id || !review || !isAuthorized) {
       return;
     }
 
-    setIsSubmitting(true);
+    setSubmittingStatus(status);
 
     try {
       await updateReview({
         id: id as Id<'reviews'>,
-        title: data.title || undefined,
+        title: data.title.trim() || undefined,
         content: data.content,
         isRecommended: data.isRecommended,
         readStatus: data.readStatus,
         status,
       });
 
-      // Navigate back to the review detail page
+      if (status === 'DRAFT') {
+        setLastSavedAt(Date.now());
+        toast.success(
+          '초안이 저장되었습니다',
+          '작성 화면에서 계속 이어쓸 수 있어요.'
+        );
+        return;
+      }
+
+      toast.success('독후감이 발행되었습니다');
       void navigate(`/reviews/${id}`);
     } catch (error) {
       logError(error, 'Failed to update review');
       toast.error('독후감 수정에 실패했습니다', '다시 시도해주세요.');
-      setIsSubmitting(false);
+    } finally {
+      setSubmittingStatus(null);
     }
   };
 
@@ -104,7 +118,9 @@ export default function ReviewEditPage() {
             요청하신 독후감이 존재하지 않거나 삭제되었습니다
           </p>
           <Button
-            onClick={() => navigate('/feed')}
+            onClick={() => {
+              Promise.resolve(navigate('/feed')).catch(() => undefined);
+            }}
             className="bg-primary-500 hover:bg-primary-600"
           >
             <ArrowLeft className="w-4 h-4 mr-2" />
@@ -120,6 +136,8 @@ export default function ReviewEditPage() {
     return null; // Will redirect in useEffect
   }
 
+  const isDraft = review.status === 'DRAFT';
+
   return (
     <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 max-w-4xl">
       {/* Header */}
@@ -127,15 +145,25 @@ export default function ReviewEditPage() {
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => navigate(`/reviews/${id}`)}
+          onClick={() => {
+            Promise.resolve(
+              navigate(isDraft ? '/dashboard' : `/reviews/${id}`)
+            ).catch(() => undefined);
+          }}
           className="mb-4 text-stone-600 hover:text-stone-900"
         >
           <ArrowLeft className="w-4 h-4 mr-2" />
-          독후감으로 돌아가기
+          {isDraft ? '내 독후감으로 돌아가기' : '독후감으로 돌아가기'}
         </Button>
 
-        <h1 className="text-3xl font-bold text-stone-900 mb-2">독후감 수정</h1>
-        <p className="text-stone-600">독후감 내용을 수정할 수 있습니다</p>
+        <h1 className="text-3xl font-bold text-stone-900 mb-2">
+          {isDraft ? '초안 이어쓰기' : '독후감 수정'}
+        </h1>
+        <p className="text-stone-600">
+          {isDraft
+            ? '초안은 발행 전까지 나만 볼 수 있습니다. 저장 후에도 이 화면에서 계속 작성하세요.'
+            : '독후감 내용을 수정할 수 있습니다'}
+        </p>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -161,7 +189,10 @@ export default function ReviewEditPage() {
                 readStatus: review.readStatus,
               }}
               onSubmit={handleSubmitReview}
-              isSubmitting={isSubmitting}
+              isSubmitting={submittingStatus !== null}
+              submittingStatus={submittingStatus}
+              currentStatus={review.status === 'DRAFT' ? 'DRAFT' : 'PUBLISHED'}
+              lastSavedAt={lastSavedAt}
             />
           </div>
         </div>

--- a/packages/frontend/src/pages/ReviewNew/ReviewNewPage.tsx
+++ b/packages/frontend/src/pages/ReviewNew/ReviewNewPage.tsx
@@ -31,19 +31,25 @@ interface ReviewFormData {
   readStatus: 'READING' | 'COMPLETED' | 'DROPPED';
 }
 
+type ReviewSubmitStatus = 'DRAFT' | 'PUBLISHED';
+
 export default function ReviewNewPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { user, isLoaded } = useUser();
   const [step, setStep] = useState<1 | 2>(1);
   const [selectedBook, setSelectedBook] = useState<BookData | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submittingStatus, setSubmittingStatus] =
+    useState<ReviewSubmitStatus | null>(null);
+  const [draftReviewId, setDraftReviewId] = useState<string | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const [showExistingReviewDialog, setShowExistingReviewDialog] =
     useState(false);
   const [hasHandledPreselectedBook, setHasHandledPreselectedBook] =
     useState(false);
 
   const createReview = useMutation(api.reviews.create);
+  const updateReview = useMutation(api.reviews.update);
   const bookIdParam = searchParams.get('bookId');
   const validBookIdParam =
     bookIdParam && /^[a-z0-9]{16,64}$/.test(bookIdParam) ? bookIdParam : null;
@@ -132,6 +138,14 @@ export default function ReviewNewPage() {
     Boolean(selectedBook && user) && existingReview === undefined;
 
   const handleBackToBookSelection = () => {
+    if (draftReviewId) {
+      toast.info(
+        '초안이 저장되어 책을 변경할 수 없습니다',
+        '다른 책으로 작성하려면 내 독후감에서 이 초안을 정리한 뒤 새로 작성해주세요.'
+      );
+      return;
+    }
+
     setStep(1);
   };
 
@@ -143,33 +157,69 @@ export default function ReviewNewPage() {
 
   const handleSubmitReview = async (
     data: ReviewFormData,
-    status: 'DRAFT' | 'PUBLISHED'
+    status: ReviewSubmitStatus
   ) => {
     if (!selectedBook || !user) {
       toast.error('로그인이 필요합니다');
       return;
     }
 
-    setIsSubmitting(true);
+    setSubmittingStatus(status);
 
     try {
-      const displayName = getUserNickname(user);
-      const reviewId = await createReview({
-        bookId: selectedBook._id,
-        title: data.title || undefined,
+      const title = data.title.trim() || undefined;
+      const payload = {
+        title,
         content: data.content,
         isRecommended: data.isRecommended,
         readStatus: data.readStatus,
         status,
+      };
+
+      if (draftReviewId) {
+        await updateReview({
+          id: draftReviewId as Id<'reviews'>,
+          ...payload,
+        });
+
+        if (status === 'DRAFT') {
+          setLastSavedAt(Date.now());
+          toast.success(
+            '초안이 저장되었습니다',
+            '작성 화면에서 계속 이어쓸 수 있어요.'
+          );
+          return;
+        }
+
+        toast.success('독후감이 발행되었습니다');
+        void navigate(`/reviews/${draftReviewId}`);
+        return;
+      }
+
+      const displayName = getUserNickname(user);
+      const reviewId = await createReview({
+        bookId: selectedBook._id,
+        ...payload,
         ...(displayName ? { displayName } : {}),
       });
 
-      // Navigate to the created review
+      if (status === 'DRAFT') {
+        setDraftReviewId(reviewId);
+        setLastSavedAt(Date.now());
+        toast.success(
+          '초안이 저장되었습니다',
+          '작성 화면에서 계속 이어쓸 수 있어요.'
+        );
+        return;
+      }
+
+      toast.success('독후감이 발행되었습니다');
       void navigate(`/reviews/${reviewId}`);
     } catch (error) {
-      logError(error, 'Failed to create review');
-      toast.error('독후감 작성에 실패했습니다', '다시 시도해주세요.');
-      setIsSubmitting(false);
+      logError(error, 'Failed to save review');
+      toast.error('독후감 저장에 실패했습니다', '다시 시도해주세요.');
+    } finally {
+      setSubmittingStatus(null);
     }
   };
 
@@ -186,7 +236,9 @@ export default function ReviewNewPage() {
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => navigate('/feed')}
+          onClick={() => {
+            Promise.resolve(navigate('/feed')).catch(() => undefined);
+          }}
           className="mb-4 text-stone-600 hover:text-stone-900 hover:bg-white/70"
         >
           <ArrowLeft className="w-4 h-4 mr-2" />
@@ -308,7 +360,8 @@ export default function ReviewNewPage() {
                 onClick={handleBackToBookSelection}
                 className="text-stone-600 hover:text-stone-900"
               >
-                <ArrowLeft className="w-4 h-4 mr-2" />책 다시 선택
+                <ArrowLeft className="w-4 h-4 mr-2" />
+                {draftReviewId ? '선택한 책 유지 중' : '책 다시 선택'}
               </Button>
             </div>
 
@@ -347,7 +400,10 @@ export default function ReviewNewPage() {
             <div className="lg:flex-1">
               <ReviewForm
                 onSubmit={handleSubmitReview}
-                isSubmitting={isSubmitting}
+                isSubmitting={submittingStatus !== null}
+                submittingStatus={submittingStatus}
+                currentStatus={draftReviewId ? 'DRAFT' : undefined}
+                lastSavedAt={lastSavedAt}
               />
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Prevent unauthorized access to drafts/deleted reviews and ensure endpoints only expose `PUBLISHED` content to other users. 
- Improve the review authoring experience with explicit draft saving, visual feedback and safer navigation flows. 

### Description
- Backend: tighten review visibility by checking `ctx.auth.getUserIdentity()` in `listByUser`, `get`, `getByUserAndBook`, and `getDetail`, returning `null` for unauthorized access and filtering out `DELETED` reviews, and only showing `DRAFT` to the owner while defaulting others to `PUBLISHED`.
- Backend: make `listByUser` compute a `visibleStatus` based on whether the requester is the owner and use it to filter the `reviews` query.
- Frontend: `ReviewForm` now distinguishes draft vs publish flows with separate validation (allow partial saves for drafts), supports async `onSubmit`, shows `submittingStatus`, content length validation, and displays `lastSavedAt` timestamps.
- Frontend: editor/new pages (`ReviewEditPage`, `ReviewNewPage`) and review detail UI updated to handle draft lifecycle: `draftReviewId` handling, `lastSavedAt`, conditional navigation back to `/dashboard`, different button labels and toasts for draft save vs publish, and preventing book change when a draft exists.
- Frontend: `ReviewDetailPage` and `MyReviewCard` updated to hide/disable interactions (like/bookmark/share) and view-count increments for non-`PUBLISHED` reviews, show a draft banner and adjust author action labels for drafts.

### Testing
- Type-check and build were run via `yarn build` and `yarn tsc` and completed successfully. 
- Lint checks were executed via `yarn lint` and passed. 
- Project tests were executed with `yarn test` and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2523dd68d4832ea21f22f8f46a233f)